### PR TITLE
Fix(yml) change yml block name from routes to interactivesroutes

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,5 +1,5 @@
 ---
-Name: routes
+Name: interactivesroutes
 ---
 SilverStripe\Control\Director:
   rules:


### PR DESCRIPTION
SilverStripe's yml name blocks must be unique, 'routes' is very generic and clashes with other modules.
Annoyingly this will require a major version bump as anyone overriding this block will need to update their configuration.