### PR TITLE
fix(Interactive) Added column to be selected by the query following MySQL 5.7 upgrade (due to 'ONLY_FULL_GROUP_BY' error)

### DIFF
--- a/src/Model/Interactive.php
+++ b/src/Model/Interactive.php
@@ -282,6 +282,9 @@ class Interactive extends DataObject
 
         $statsQuery = InteractiveImpression::get()->dataQuery()->getFinalisedQuery(["ID", "Interaction"]);
         $statsQuery->setWhere('"InteractiveID" = ' . (int) $this->ID);
+        $statsQuery->setSelect(array(
+            'Interaction' => '"Interaction"'
+        ));
         $statsQuery->addGroupBy("Interaction");
         $statsQuery->selectField("count(*) as Number");
 


### PR DESCRIPTION
Due to stricter GroupBy on MySQL 5.7, any column has to be selected by the query in order to group them properly. 